### PR TITLE
Update/1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,49 +3,27 @@ jobs:
   build:
     docker:
       - image: circleci/ruby:2.4.6
-
-    working_directory: ~/repo
-
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "Gemfile.lock" }}
-          # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
-
       - run:
-          name: install dependencies
-          command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
-
+          name: Install gem dependencies
+          command: gem install bundler && bundle install
       - save_cache:
           paths:
             - ./vendor/bundle
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
-
-      # Database setup
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
-
-      # run tests!
       - run:
-          name: run tests
-          command: |
-            mkdir /tmp/test-results
-            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+          name: Run tests
+          command: bundle exec rspec
 
-            bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
-                            --out /tmp/test-results/rspec.xml \
-                            --format progress \
-                            $TEST_FILES
-
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org).
 
 
+## [1.2.0] - 2019-07-25
+
+### Changed
+
+- move `rails` to be a development dependency
+- depend only on `activerecord` and `activestorage`, both `>= 4.2`
+
+[1.2.0]: https://github.com/sharoo/easy_orderable/compare/v1.1.1...v1.2.0
+
 ## [1.1.1] - 2019-07-25
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     easy_orderable (1.2.0)
       activerecord (>= 4.2)
+      activesupport (>= 4.2)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    easy_orderable (0.2.2)
-      rails
+    easy_orderable (1.2.0)
+      activerecord (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -146,10 +146,11 @@ PLATFORMS
 
 DEPENDENCIES
   easy_orderable!
-  factory_bot_rails
-  rspec-rails
-  rspec_junit_formatter
-  sqlite3
+  factory_bot_rails (~> 5.0, >= 5.0.2)
+  rails (>= 4.2)
+  rspec-rails (~> 3.8, >= 3.8.1)
+  rspec_junit_formatter (~> 0.4.1)
+  sqlite3 (~> 1.3, >= 1.3.13)
 
 BUNDLED WITH
-   1.17.3
+   2.0.2

--- a/easy_orderable.gemspec
+++ b/easy_orderable.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*']
 
   s.add_dependency 'activerecord', '>= 4.2'
+  s.add_dependency 'activesupport', '>= 4.2'
 
   s.add_development_dependency 'rails', '>= 4.2'
   s.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.13'

--- a/easy_orderable.gemspec
+++ b/easy_orderable.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 5.2', '>= 5.2.3'
+  s.add_dependency 'activerecord', '>= 4.2'
 
+  s.add_development_dependency 'rails', '>= 4.2'
   s.add_development_dependency 'sqlite3', '~> 1.3', '>= 1.3.13'
   s.add_development_dependency 'rspec-rails', '~> 3.8', '>= 3.8.1'
   s.add_development_dependency 'factory_bot_rails', '~> 5.0', '>= 5.0.2'

--- a/lib/easy_orderable/version.rb
+++ b/lib/easy_orderable/version.rb
@@ -1,3 +1,3 @@
 module EasyOrderable
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/easy_orderable_spec.rb
+++ b/spec/easy_orderable_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper.rb'
 
 describe EasyOrderable do
-  it { expect(described_class::VERSION).to eq('1.1.1') }
+  it { expect(described_class::VERSION).to eq('1.2.0') }
 
   describe '#assort' do
     let!(:user_a) { create(:user, name: 'A') }


### PR DESCRIPTION
### Changed

- move `rails` to be a development dependency
- depend only on `activerecord` and `activestorage`, both `>= 4.2`